### PR TITLE
Added vertical touch scrolling functionality

### DIFF
--- a/jquery.cycle.all.js
+++ b/jquery.cycle.all.js
@@ -487,6 +487,13 @@ function integrateTouch (opts, cont) {
 		var dragMove = function (event) {
 			window.cycle_touchMoveCurrentPos = getTouchPos(event);
 			event.preventDefault();
+			
+		  // Fix to allow touch scrolling. Added by Grady.
+		  var scrollDif = window.cycle_touchMoveCurrentPos.pageY - initPos.pageY;
+      
+      if ( dragstate == 'locked' ) {
+        $(window).scrollTop($(window).scrollTop() - scrollDif);
+      }
 		}
 
 		window.cycle_touchMoveCurrentPos = getTouchPos();


### PR DESCRIPTION
I encountered a need to be able to touch scroll vertically while still being able to drag slides horizontally for full-screen-width slideshows. From what I was able to tell, iOS has implemented a fix to allow preventDefault to fire after the first iteration of the touchMove event, which worked really well on iOS devices in a past commit where you had:

if ( dragstate == 'dragging' ) {
  event.preventDefault();
}

However, as you probably found, Android only allows preventDefault to be fired on touchStart or the first iteration of touchMove. My solution for this is not device independent, and not ideal, but it works. Another solution could be to use your original solution on iOS, and some version (hopefully a better one) of my solution for other devices. I could not figure out how you were doing device detection. I also did not account for horizontal scrolling on vertically dragging slideshows.
